### PR TITLE
Updating workspace Dockerfile

### DIFF
--- a/etc/workspace/Dockerfile-56
+++ b/etc/workspace/Dockerfile-56
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:latest-amd64
 
 MAINTAINER Maxime HELIAS <maximehelias16@gmail.com>
 


### PR DESCRIPTION
This will resolve the issue that the image with name `phusion/baseimage:latest` doesn't exist on Docker Hub