### PR TITLE
fixing nginx version

### DIFF
--- a/etc/nginx/Dockerfile
+++ b/etc/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.14.2-alpine
 
 MAINTAINER Maxime HELIAS <maximehelias16@gmail.com>
 


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/56960355/docker-compose-throws-adduser-group-www-data-in-use nginx version image have to be fixed OR command must be changed to `adduser -D -H -u 1000 -s /bin/bash www-data -G www-data`